### PR TITLE
Verified on Lenovo IdeaPad Slim 5 (15ARP10) and LG Gram (16Z90TL)

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -9,6 +9,7 @@ These devices have been tested and confirmed working with this fix:
 | Brand | Model | Key Replaced | Status |
 |-------|-------|-------------|--------|
 | ASUS | Zenbook S 16 (UM5606) | Right Ctrl | Verified |
+| Lenovo | IdeaPad Slim 5 (15ARP10) | Right Ctrl | Verified |
 
 ## Likely Compatible
 

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -83,6 +83,12 @@ These devices are known to have the Copilot key and should work with this fix (s
 |-------|-------------|-------|
 | Surface Laptop (7th gen) | Right Win / Menu | |
 
+### LG
+
+| Model | Key Replaced | Notes |
+|-------|-------------|-------|
+| LG gram 16Z90TL | Copilot Key is Right of Right-Alt | |
+
 ## Is the Copilot Key the Same Across Brands?
 
 **Yes.** Microsoft mandated that the Copilot key sends **LWin + LShift + F23** on all OEMs. Dell has explicitly confirmed this is "standard for the Copilot key and done at Microsoft's direction." There are no known brand-specific variations in the key signal.

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -10,6 +10,7 @@ These devices have been tested and confirmed working with this fix:
 |-------|-------|-------------|--------|
 | ASUS | Zenbook S 16 (UM5606) | Right Ctrl | Verified |
 | Lenovo | IdeaPad Slim 5 (15ARP10) | Right Ctrl | Verified |
+| LG | gram 16Z90TL | Right Ctrl | Verified |
 
 ## Likely Compatible
 
@@ -87,7 +88,7 @@ These devices are known to have the Copilot key and should work with this fix (s
 
 | Model | Key Replaced | Notes |
 |-------|-------------|-------|
-| LG gram 16Z90TL | Copilot Key is Right of Right-Alt | |
+| LG gram 16Z90TL | Right Ctrl | |
 
 ## Is the Copilot Key the Same Across Brands?
 


### PR DESCRIPTION
Tested and verified working on my `Lenovo IdeaPad Slim 5 (15ARP10)` device.

Also a huge thank you for this. I already had an AHK script run on startup for other uses and this was a really simple addition to give me back rCtrl key. 💜 